### PR TITLE
Fix CI on Windows and Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Run mypy
         run: |
           source $VENV
-          make mypy
+          mypy parametrize
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: ~/.cache
+          path: ["~/.cache", "poetry.lock"]
           key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
@@ -65,7 +65,7 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: ["~/.cache", "poetry.lock"]
+          path: ~/.cache
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             ~/cache
             poetry.lock
-        key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: flake8
-        run: |
-          flake8 parametrize tests
+        run: flake8 parametrize tests
 
   test:
     needs: lint
@@ -76,12 +75,10 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run mypy
-        run: |
-          mypy parametrize
+        run: mypy parametrize
 
       - name: Run tests
-        run: |
-          pytest tests --cov=parametrize
+        run: pytest tests --cov=parametrize
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         with:
         path: |
           ~/cache
-          poetry.lock
         key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,34 +20,29 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
-      - name: Load cached venv
-        id: cached-poetry-dependencies
+      - name: Load cached wheels
+        id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: .venv
+          path: ~/.cache
           key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
 
       - name: flake8
         run: |
-          source $VENV
-          make flake8
+          flake8 parametrize tests
 
   test:
     needs: lint
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest"]
-#        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6"]
-#        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
     defaults:
       run:
         shell: bash  # required for windows
@@ -64,31 +59,25 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
-      - name: Load cached venv
-        id: cached-poetry-dependencies
+      - name: Load cached wheels
+        id: cached-pip-wheels
         uses: actions/cache@v2
-        # Windows has problems with cached venv
-        if: matrix.os != 'windows-latest'
         with:
-          path: .venv
-          key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          path: ~/.cache
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
 
       - name: Run mypy
         run: |
-          source $VENV
           mypy parametrize
 
       - name: Run tests
         run: |
-          source $VENV
-          make test
+          pytest tests --cov=parametrize
 
 
   deploy:
@@ -104,8 +93,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
       - name: Install poetry-dynamic-versioning
         run: python -m pip install pip install poetry-dynamic-versioning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: [~/.cache, poetry.lock]
+          path: ["~/.cache", "poetry.lock"]
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-        path: |
-          ~/cache
+          path: |
+            ~/cache
+            poetry.lock
         key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: ["~/.cache", "poetry.lock"]
-          key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
+        path: |
+          ~/cache
+          poetry.lock
+        key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
@@ -65,7 +67,9 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: ~/.cache
+          path: |
+            ~/cache
+            poetry.lock
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         id: cached-pip-wheels
         uses: actions/cache@v2
         with:
-          path: ~/.cache
+          path: [~/.cache, poetry.lock]
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,6 @@ jobs:
       - name: Run mypy
         run: |
           source $VENV
-          python --version
-          which python
-          python -m mypy
           mypy parametrize
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        os: ["windows-latest"]
+#        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.6"]
+#        python-version: ["3.6", "3.7", "3.8", "3.9"]
     defaults:
       run:
         shell: bash  # required for windows
@@ -79,6 +81,9 @@ jobs:
       - name: Run mypy
         run: |
           source $VENV
+          python --version
+          which python
+          python -m mypy
           mypy parametrize
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v2
+        # Windows has problems with cached venv
+        if: matrix.os != 'windows-latest'
         with:
           path: .venv
           key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}


### PR DESCRIPTION
For some reason it fails on attempt to run mypy:
```py
source $VENV
mypy parametrize
mingw32-make: *** [Makefile:23: mypy] Error -1073741792
Error: Process completed with exit code 2.
```
Full CI log: [logs_14.zip](https://github.com/MrMrRobat/parametrize/files/6444011/logs_14.zip)

When I call mypy without make:
```py
  source $VENV
  mypy parametrize
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.6.8\x64
    VENV: .venv/scripts/activate
Error: Process completed with exit code 127.
```
Full CI log: [logs_16.zip](https://github.com/MrMrRobat/parametrize/files/6444021/logs_16.zip)

### Solution

Turns out, caching `venv` was causing the issue. 

I moved from caching `venv` to caching wheels and `poetry.lock` and it solved the problem.